### PR TITLE
Check for installed software for on-demand instance cost

### DIFF
--- a/cloud_provider/aws/aws_bid_advisor.py
+++ b/cloud_provider/aws/aws_bid_advisor.py
@@ -123,6 +123,7 @@ class AWSBidAdvisor(object):
                         "OnDemand" in row["TermType"] and \
                         region_full_name in row["Location"] and \
                         row["Operating System"] == "Linux" and \
+                        row["Pre Installed S/W"] == "NA" and \
                         row["Tenancy"] == "Shared":
                     self.bid_advisor.on_demand_price_dict[
                         row["Instance Type"]] = row["PricePerUnit"]


### PR DESCRIPTION
Issue:
The current price calculation for on-demand instances is not filtering by "Pre Installed SW". When it calculates the price for an instance type (i.e. m5.xlarge), multiple options are available from the AWS pricing API. Typically, these will be a few options with pre-installed software like SQL, and the base instance type with "NA" installed. This change will only look at the base instance types with no pre-installed software option. 

Before this change for m5.xlarge in us-west-2

```
Using spot_instance price 0.084000, on-demand price 0.672000 for instance type: m5.xlarge, zones: ['us-west-2a', 'us-west-2b', 'us-west-2c']
```

After this change:
```
Using spot_instance price 0.084200, on-demand price 0.192000 for instance type: m5.xlarge, zones: ['us-west-2a', 'us-west-2b', 'us-west-2c']
```