### PR TITLE
Rolling update instances in ASG

### DIFF
--- a/cloud_provider/aws/aws_minion_manager.py
+++ b/cloud_provider/aws/aws_minion_manager.py
@@ -5,7 +5,6 @@ import sys
 import time
 import base64
 from datetime import datetime
-#from random import randint
 from threading import Timer, Semaphore
 import boto3
 from botocore.exceptions import ClientError

--- a/cloud_provider/aws/aws_minion_manager_test.py
+++ b/cloud_provider/aws/aws_minion_manager_test.py
@@ -311,3 +311,23 @@ class AWSMinionManagerTest(unittest.TestCase):
         instance = asg_meta.get_instances()[0]
         assert len(awsmm.price_reporter.price_info[
             instance.InstanceId]) == 2
+
+    # Setting semaphore Value
+    @mock_autoscaling
+    @mock_ec2
+    @mock_sts
+    def test_set_semaphore(self):
+        """
+        Testing Semaphore value based on terminate percentage
+        """
+        def _semaphore_helper(minion_manager_tag, percentage, outcome):
+            awsmm = self.basic_setup_and_test(minion_manager_tag)
+            asg_meta = awsmm.get_asg_metas()[0]
+            awsmm.terminate_percentage = percentage
+            get_semaphore = awsmm.set_semaphore(asg_meta)
+            assert get_semaphore._Semaphore__value == outcome
+   
+        _semaphore_helper('use-spot', 1, 1)
+        _semaphore_helper('use-spot', 30, 1)
+        _semaphore_helper('use-spot', 60, 2)
+        _semaphore_helper('use-spot', 100, 3)


### PR DESCRIPTION
related #9 

## Rolling update instances in ASG
- By default, all instances in an ASG will be rolling updated. Also added explicit 180 seconds sleep before checking ASG for a healthy count to avoid API throttling from AWS 
- Terminate percentage value can be changed between 1 to 100 ( This value is hardcoded to `1` today meaning it will only do rolling update. In future, this can be changed as ASG Tag to customized terminate_percentage per ASG)

## Testing 
- Added unit test for calculating semaphore value, Unit testing is completed. 
- Manual testing is done
  - ASG with 3 instances rotated one instance at a time ( when a k8s-minion-manager tag is set to use-spot) and all instances switched to spot.
  - Switch back to use on-demand has exact same behavior (rotated one instance at a time).
  - Tested using a sample Nginx deployment with 3 replicas, There was no downtime for the app during the rolling update.
