### PR TITLE
update tag and IAM perms in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ The IAM role of the node that runs the minion-manager should have the following 
     "Sid": "kopsK8sMinionManager",
     "Effect": "Allow",
     "Action": [
+	"ec2:DescribeInstances",
 	"ec2:TerminateInstances",
 	"ec2:DescribeSpotPriceHistory",
 	"autoscaling:CreateLaunchConfiguration",
 	"autoscaling:DeleteLaunchConfiguration",
-	"autoscaling:DescribeLaunchConfiguration",
+	"autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "autoscaling:UpdateAutoScalingGroup",

--- a/deploy/mm.yaml
+++ b/deploy/mm.yaml
@@ -38,7 +38,7 @@ spec:
             serviceAccountName: mm-sa
             containers:
               - name: minion-manager
-                image: argoproj/k8s-minion-manager:v0.3
+                image: argoproj/k8s-minion-manager:v0.6
                 command: ["python", "./minion_manager.py", "--region", "us-west-2", "--cluster-name", "<my-cluster-name>"]
                 resources:
                     requests:


### PR DESCRIPTION
@shrinandj I realize now that the bug I was experiencing was actually fixed in v0.4 of the code. I applied the mm.yaml as is (still on v0.3) and that is why I experienced the bug. I updated the mm.yaml to the refer to the latest tag (v0.6 not sure if we should do that or latest tag).

I also updated the IAM permissions required in the README since I ran into some issues there as well. 
ec2:DescribeInstances is needed for line 81 in aws_minion_manager.py
DescribeLaunchConfiguration needs to be plural.