### PR TITLE
Add check on ASG activities insufficient resource

### DIFF
--- a/cloud_provider/aws/aws_minion_manager.py
+++ b/cloud_provider/aws/aws_minion_manager.py
@@ -666,7 +666,7 @@ class AWSMinionManager(MinionManagerBase):
                                            'capacity in the Availability Zone you requested']
         
         asg_info = scaling_group.get_asg_info()
-        response = AWSMinionManager.describe_asg_with_retries(
+        response = AWSMinionManager.describe_asg_activities_with_retries(
             self._ac_client, asg_info.AutoScalingGroupName)
         activities = response.Activities
         

--- a/cloud_provider/aws/aws_minion_manager.py
+++ b/cloud_provider/aws/aws_minion_manager.py
@@ -74,6 +74,16 @@ class AWSMinionManager(MinionManagerBase):
 
     @staticmethod
     @retry(wait_exponential_multiplier=1000, stop_max_attempt_number=3)
+    def describe_asg_activities_with_retries(ac_client, asg):
+        """
+        AWS describe_auto_scaling_groups with retries.
+        """
+        response = ac_client.describe_scaling_activities(
+            AutoScalingGroupName=asg)
+        return bunchify(response)
+
+    @staticmethod
+    @retry(wait_exponential_multiplier=1000, stop_max_attempt_number=3)
     def get_instances_with_retries(ec2_client, instance_ids):
         """
         AWS describe_instances with retries.
@@ -545,9 +555,7 @@ class AWSMinionManager(MinionManagerBase):
                     # 3.
                     bid_info = asg_meta.get_bid_info()
                     if asg_meta.get_mm_tag() == "no-spot" and bid_info["type"] == "spot":
-                        new_bid_info = {}
-                        new_bid_info["type"] = "on-demand"
-                        new_bid_info["price"] = ""
+                        new_bid_info = self.create_on_demand_bid_info()
                         logger.info("ASG %s configured with no-spot but currently using spot. Updating...", asg_meta.get_name())
                         self.update_scaling_group(asg_meta, new_bid_info)
                         continue
@@ -555,6 +563,13 @@ class AWSMinionManager(MinionManagerBase):
                     new_bid_info = self.bid_advisor.get_new_bid(
                         zones=asg_meta.asg_info.AvailabilityZones,
                         instance_type=asg_meta.lc_info.InstanceType)
+                    
+                    # Change ASG to on-demand if insufficient capacity
+                    if self.check_insufficient_capacity(asg_meta):
+                        new_bid_info = self.create_on_demand_bid_info()
+                        logger.info("ASG %s spot instance have not sufficient resource. Updating to on-demand...", asg_meta.get_name())
+                        self.update_scaling_group(asg_meta, new_bid_info)
+                        continue
 
                     # Update ASGs iff new bid is different from current bid.
                     if self.are_bids_equal(asg_meta.bid_info, new_bid_info):
@@ -578,6 +593,12 @@ class AWSMinionManager(MinionManagerBase):
                     self.populate_current_config()
                 except Exception as ex:
                     raise Exception("Failed to discover/populate current ASG info: " + str(ex))
+
+    def create_on_demand_bid_info(self):
+        new_bid_info = {}
+        new_bid_info["type"] = "on-demand"
+        new_bid_info["price"] = ""
+        return new_bid_info
 
     def run(self):
         """Entrypoint for the AWS specific minion-manager."""
@@ -635,7 +656,28 @@ class AWSMinionManager(MinionManagerBase):
                 # Wait for sometime before checking again.
                 time.sleep(60)
         return False
-
+    
+    def check_insufficient_capacity(self, scaling_group):
+        """
+        Checks whether not completed ASG activities got not have sufficient capacity error message.
+        """
+        # This error message from https://docs.aws.amazon.com/autoscaling/ec2/userguide/ts-as-capacity.html#ts-as-capacity-1
+        INSUFFICIENT_CAPACITY_MESSAGE = ['We currently do not have sufficient',
+                                           'capacity in the Availability Zone you requested']
+        
+        asg_info = scaling_group.get_asg_info()
+        response = AWSMinionManager.describe_asg_with_retries(
+            self._ac_client, asg_info.AutoScalingGroupName)
+        activities = response.Activities
+        
+        for activity in activities:
+            if activity.Progress == 100:
+                continue
+            if len([message for message in INSUFFICIENT_CAPACITY_MESSAGE if message in activity.StatusMessage]) == len(INSUFFICIENT_CAPACITY_MESSAGE):
+                return True
+            
+        return False
+        
     def get_asg_metas(self):
         """ Return all asg_meta """
         return self._asg_metas

--- a/cloud_provider/aws/aws_minion_manager.py
+++ b/cloud_provider/aws/aws_minion_manager.py
@@ -673,7 +673,7 @@ class AWSMinionManager(MinionManagerBase):
         for activity in activities:
             if activity.Progress == 100:
                 continue
-            if len([message for message in INSUFFICIENT_CAPACITY_MESSAGE if message in activity.StatusMessage]) == len(INSUFFICIENT_CAPACITY_MESSAGE):
+            if 'StatusMessage' in activity and len([message for message in INSUFFICIENT_CAPACITY_MESSAGE if message in activity.StatusMessage]) == len(INSUFFICIENT_CAPACITY_MESSAGE):
                 return True
             
         return False

--- a/cloud_provider/aws/aws_minion_manager_test.py
+++ b/cloud_provider/aws/aws_minion_manager_test.py
@@ -361,7 +361,7 @@ class AWSMinionManagerTest(unittest.TestCase):
         awsmm.cordon_node("ip-of-fake-node")
         mock_check_call.assert_called_with(['kubectl', 'uncordon', 'ip-of-fake-node-name'])
 
-    @mock.patch('cloud_provider.aws.aws_minion_manager.AWSMinionManager.describe_asg_with_retries')
+    @mock.patch('cloud_provider.aws.aws_minion_manager.AWSMinionManager.describe_asg_activities_with_retries')
     @mock_autoscaling
     @mock_ec2
     @mock_sts
@@ -373,7 +373,7 @@ class AWSMinionManagerTest(unittest.TestCase):
         assert not awsmm.check_insufficient_capacity(asg_meta)
 
 
-    @mock.patch('cloud_provider.aws.aws_minion_manager.AWSMinionManager.describe_asg_with_retries')
+    @mock.patch('cloud_provider.aws.aws_minion_manager.AWSMinionManager.describe_asg_activities_with_retries')
     @mock_autoscaling
     @mock_ec2
     @mock_sts
@@ -384,7 +384,7 @@ class AWSMinionManagerTest(unittest.TestCase):
         asg_meta = awsmm.get_asg_metas()[0]
         assert not awsmm.check_insufficient_capacity(asg_meta)
 
-    @mock.patch('cloud_provider.aws.aws_minion_manager.AWSMinionManager.describe_asg_with_retries')
+    @mock.patch('cloud_provider.aws.aws_minion_manager.AWSMinionManager.describe_asg_activities_with_retries')
     @mock_autoscaling
     @mock_ec2
     @mock_sts
@@ -395,7 +395,7 @@ class AWSMinionManagerTest(unittest.TestCase):
         asg_meta = awsmm.get_asg_metas()[0]
         assert not awsmm.check_insufficient_capacity(asg_meta)
 
-    @mock.patch('cloud_provider.aws.aws_minion_manager.AWSMinionManager.describe_asg_with_retries')
+    @mock.patch('cloud_provider.aws.aws_minion_manager.AWSMinionManager.describe_asg_activities_with_retries')
     @mock_autoscaling
     @mock_ec2
     @mock_sts


### PR DESCRIPTION
This want to solve #13 
When hit this code.
Means already have spot instance can't provision longer then 3 mins.
So check is any activity's StatusMessage got insufficient error message.
If yes, change the launch type to on-demand.
I didn't make any record on it.
So on next check. It should auto change back to spot instance.

There are something didn't solve.
1. Not tested with `moto`. They didn't implement `describe_auto_scaling_groups`. So no test case added.
1. Not tested with real situation. Difficult to hit that =.="