### PR TITLE
fix(aws_bid_advisor.py) Fixing SpotPrice bid in basic_bid_strategy

### DIFF
--- a/cloud_provider/aws/aws_bid_advisor.py
+++ b/cloud_provider/aws/aws_bid_advisor.py
@@ -260,7 +260,7 @@ class AWSBidAdvisor(object):
         threshold = bid_options["spot_to_on_demand_threshold"]
 
         if spot_price <= threshold * on_demand_price:
-            bid_info["price"] = str(on_demand_price)
+            bid_info["price"] = str(spot_price)
             bid_info["type"] = "spot"
         else:
             # On-demand nodes do not require price information.


### PR DESCRIPTION
Sorry for not creating an issue for this case, but the `basic_bid_strategy` function is using the wrong variable to set the `bid_info["price"]` when `spot` is the type.

Log of what was happening when  I set the price below the current spot price (_0.5_):

```
2019-03-25T21:43:31 INFO aws.minion-manager.bid-advisor MainThread: Using spot_instance price 0.067700, on-demand price 0.200000 for instance type: m4.xlarge, zones: ['us-east-1b']
2019-03-25T21:43:31 INFO aws_minion_manager MainThread: Got new bid info from BidAdvisor: {'price': '0.2', 'type': 'spot'}
2019-03-25T21:43:31 INFO aws_minion_manager MainThread: Updating ASG: <asg name removed>, Bid: {'price': '0.2', 'type': 'spot'}
2019-03-25T21:43:31 INFO aws_minion_manager MainThread: ASG(<asg name removed>): New bid price 0.2
```

_Removed ASG name from my company_