### PR TITLE
Add ASG tag to control terminate instance or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Then, `kubectl apply -f deploy/mm.yaml`.
     * "use-spot": This will make the minion-manager intelligently use spot instances in the ASG
     * "no-spot": This will make the minion-manager always use on-demand instances in the ASG. This is useful when someone wants to temporarily switch to on-demand instances and at a later point switch to "use-spot"
     * Note that after changing the tag value, it may take upto 5 minutes for the minion-manager pod to see the changes and make them take effect.
+* The "k8s-minion-manager/not-terminate" tag can control ASG instance terminate by the minion-manager. If you want to control when to terminate ASG instances. You can set this tag to `true`. If not set or other value will disable this feature.
 
 **What happens when:**
 

--- a/cloud_provider/aws/asg_mm.py
+++ b/cloud_provider/aws/asg_mm.py
@@ -1,4 +1,6 @@
 """ Metadata for each Autoscaling group in AWS. """
+MINION_MANAGER_LABEL = 'k8s-minion-manager'
+NOT_TERMINATE_LABEL = MINION_MANAGER_LABEL+'/not-terminate'
 
 
 class AWSAutoscalinGroupMM(object):
@@ -30,9 +32,14 @@ class AWSAutoscalinGroupMM(object):
         assert asg_info is not None, "Can't set ASG info to None!"
         self.asg_info = asg_info
         for tag in self.asg_info['Tags']:
-            if tag.get('Key', None) == 'k8s-minion-manager':
+            if tag.get('Key', None) == MINION_MANAGER_LABEL:
                 if tag['Value'] not in ("use-spot", "no-spot"):
                     tag['Value'] = 'no-spot'
+            elif tag.get('Key', None) == NOT_TERMINATE_LABEL:
+                if tag['Value'] in ('true', 'True', 'TRUE'):
+                    tag['Value'] = True
+                else:
+                    tag['Value'] = False
 
     def set_lc_info(self, lc_info):
         """ Sets the lc_info. """
@@ -83,7 +90,7 @@ class AWSAutoscalinGroupMM(object):
 
     def get_mm_tag(self):
         for tag in self.asg_info['Tags']:
-            if tag.get('Key', None) == 'k8s-minion-manager':
+            if tag.get('Key', None) == MINION_MANAGER_LABEL:
                 return tag['Value'].lower()
         return "no-spot"
 
@@ -108,3 +115,10 @@ class AWSAutoscalinGroupMM(object):
             return False
 
         return True
+
+    def not_terminate_instance(self):
+        """ Retures is the ASG set not terminate instance """
+        for tag in self.asg_info['Tags']:
+            if tag.get('Key', None) == NOT_TERMINATE_LABEL:
+                return tag['Value']
+        return False


### PR DESCRIPTION
I added ASG tag `k8s-minion-manager/not-terminate` to control is the manager terminate instance. If set the value to `true`/`True`/`TRUE`. Manager will not terminate that ASG's instances. 

Also move `k8s-minion-manager` to a consistent

* Testing Done:
  * Added unit tests.
  * Tested with real ASG