### PR TITLE
Remove deprecated option 'monitor-nodes'

### DIFF
--- a/minion_manager.py
+++ b/minion_manager.py
@@ -40,8 +40,6 @@ def run():
     parser.add_argument("--refresh-interval-seconds", default="300",
                         help="Interval in seconds at which to query AWS")
     parser.add_argument("--cluster-name", required=True, help="Name of the Kubernetes cluster. Get's used for identifying ASGs")
-    parser.add_argument("--monitor-nodes", default=False,
-                        help="Check if nodes are 'Ready' and terminate if not")
 
     usr_args = parser.parse_args()
     validate_usr_args(usr_args)
@@ -53,7 +51,7 @@ def run():
     if usr_args.cloud == "aws":
         minion_manager = Broker.get_impl_object(
             usr_args.cloud, usr_args.cluster_name, usr_args.region, int(usr_args.refresh_interval_seconds),
-            aws_profile=usr_args.profile, monitor_nodes=usr_args.monitor_nodes)
+            aws_profile=usr_args.profile)
         minion_manager.run()
 
 # A journey of a thousand miles ...


### PR DESCRIPTION
Testing Done:

1. Verified that the unit-tests succeed.
2. Verified that switching from on-demand to spot instances work as expected.
3. Verified that switching from spot to on-demand instances work as expected.